### PR TITLE
setup: remove test dir from found packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="novatech409b",
     install_requires=["sipyco", "asyncserial"],
-    packages=find_packages(),
+    packages=find_packages(exclude=("test",)),
     entry_points={
         "console_scripts": [
             "aqctl_novatech409b = novatech409b.aqctl_novatech409b:main",


### PR DESCRIPTION
setuptools finds the /test/ directory because it has an ``__init__.py`` file.
Hence, it is automatically copied to the site-packages directory when this package is installed, causing issues like https://github.com/m-labs/artiq/issues/1575.
This commit explicitly disables the test directory from being included in the output.